### PR TITLE
minor code changes

### DIFF
--- a/private/components/molecules/whereAreThePoorViz/index.js
+++ b/private/components/molecules/whereAreThePoorViz/index.js
@@ -42,7 +42,6 @@ class Poor extends React.Component {
   }
 
   renderVisualization() {
-    let data = [];
     /* eslint-disable react/no-string-refs */
     const svg = d3.select(this.refs.svg);
     const width = 940;
@@ -50,17 +49,16 @@ class Poor extends React.Component {
     const scale = d3.scaleSqrt().domain([1, 1500]).range([2, 150]);
     const colMap = utils.colMap;
     const {year, indicator, level, change} = this.state;
-    data = utils.entities.map(item => {
-      const value = utils.getValue(item.id, year, indicator);
-      return {...item, value};
-    });
-    data = data.filter(item => item.level === 'region');
-    data = data.map(item => ({...item, icons: Math.round(item.value / 5)}));
     const shape = 'M0-21L0-21L0-21c2.146,0.002,4.086,0.869,5.491,2.274   s2.272,3.346,2.273,5.488l0,0v0.003v0.001l0,0c-0.001,2.143-0.869,4.085-2.273,5.49C5.083-7.337,4.631-6.977,4.144-6.668H4.24   c3.612,0,6.567,2.955,6.567,6.566v12.567h-21.614V-0.102c0-3.611,2.955-6.566,6.566-6.566h0.097    c-0.588-0.309-0.94-0.569-1.348-1.076c-1.404-1.404-2.271-3.346-2.272-5.488h-0.001v-0.002v-0.001h0.001    c0-2.145,0.868-4.085,2.272-5.49c1.405-1.405,3.346-2.272,5.489-2.273V-21H0z';
-
     let iconData = [];
-
     const labelPlacement = {};
+    const data = utils.entities
+      .map(item => {
+        const value = utils.getValue(item.id, year, indicator);
+        return {...item, value};
+      })
+      .filter(item => item.level === 'region')
+      .map(item => ({...item, icons: Math.round(item.value / 5)}));
     data.forEach(o => {
       const startX = utils.getX(o.id);
       const startY = utils.getY(o.id);


### PR DESCRIPTION
@kraib The renderVisualization function is too long. Please break it down into much smaller functions with meaningful names.

Try to keep variable mutations to the very minimal. Prefer ```const``` to ```let``` I saw a lot of use of let variables. 

The ```poor people viz util file``` will also need to be eslint enabled in the near future.

Lastly instead of importing in the all d3 try to import in only the bits we are using i.e

```
import {nest} from "d3";
```
This does help in eliminating unused code.